### PR TITLE
Add updated_at to the allowed params for get_net_devices

### DIFF
--- a/ncm/ncm/ncm.py
+++ b/ncm/ncm/ncm.py
@@ -1159,7 +1159,7 @@ class NcmClientv2(BaseNcmClient):
                           'connection_state__in', 'fields', 'id', 'id__in',
                           'is_asset', 'ipv4_address', 'ipv4_address__in',
                           'mode', 'mode__in', 'router', 'router__in',
-                          'expand', 'limit', 'offset']
+                          'expand', 'limit', 'offset', 'updated_at__gt', 'updated_at__lt']
         params = self.__parse_kwargs(kwargs, allowed_params)
 
         return self.__get_json(get_url, call_type, params=params)


### PR DESCRIPTION
I noticed that the v2 API didn't have the `updated_at` param in the allowed list.

This PR adds it so that data can be filtered by this param.